### PR TITLE
fix: correct timestamp comparison in VaultExample.isWithdrawable()

### DIFF
--- a/src/CoreWriterLib.sol
+++ b/src/CoreWriterLib.sol
@@ -47,7 +47,7 @@ library CoreWriterLib {
         address systemAddress = getSystemAddress(token);
         if (isHype(token)) {
             (bool success,) = systemAddress.call{value: evmAmount}("");
-            require(success, "HYPE transfer failed");
+            if (!success) revert CoreWriterLib__HypeTransferFailed();
         } else {
             PrecompileLib.TokenInfo memory info = PrecompileLib.tokenInfo(uint32(token));
             address tokenAddress = info.evmContract;
@@ -78,7 +78,7 @@ library CoreWriterLib {
 
     function spotSend(address to, uint64 token, uint64 amountWei) internal {
         // Self-transfers will always fail, so reverting here
-        require(to != address(this), "Cannot self-transfer");
+        if (to == address(this)) revert CoreWriterLib__CannotSelfTransfer();
 
         coreWriter.sendRawAction(
             abi.encodePacked(uint8(1), HLConstants.SPOT_SEND_ACTION, abi.encode(to, token, amountWei))

--- a/src/examples/StakingExample.sol
+++ b/src/examples/StakingExample.sol
@@ -10,6 +10,8 @@ import {CoreWriterLib, HLConstants, HLConversions} from "@hyper-evm-lib/src/Core
 contract StakingExample {
     using CoreWriterLib for *;
 
+    error NoHypeBalance();
+
     /**
      * @notice Transfers HYPE tokens to core, stakes them, and delegates to a validator
      */
@@ -52,7 +54,7 @@ contract StakingExample {
      */
     function transferAllHypeToSender() external {
         uint256 balance = address(this).balance;
-        require(balance > 0, "No HYPE balance to transfer");
+        if (balance == 0) revert NoHypeBalance();
         payable(msg.sender).transfer(balance);
     }
 

--- a/src/examples/VaultExample.sol
+++ b/src/examples/VaultExample.sol
@@ -97,7 +97,7 @@ contract VaultExample {
      */
     function isWithdrawable(address user, address vault) public view returns (bool withdrawable) {
         PrecompileLib.UserVaultEquity memory vaultEquity = PrecompileLib.userVaultEquity(user, vault);
-        return block.timestamp >= vaultEquity.lockedUntilTimestamp;
+        return CoreWriterLib.toMilliseconds(uint64(block.timestamp)) >= vaultEquity.lockedUntilTimestamp;
     }
 
     receive() external payable {}

--- a/src/registry/TokenRegistry.sol
+++ b/src/registry/TokenRegistry.sol
@@ -76,7 +76,7 @@ contract TokenRegistry {
      */
     function getTokenAddress(uint32 index) public view returns (address) {
         (bool success, bytes memory result) = TOKEN_INFO_PRECOMPILE_ADDRESS.staticcall(abi.encode(index));
-        require(success, "TokenInfo precompile call failed");
+        if (!success) revert PrecompileCallFailed();
         TokenInfo memory info = abi.decode(result, (TokenInfo));
         return info.evmContract;
     }
@@ -99,4 +99,5 @@ contract TokenRegistry {
 
     error TokenNotFound(address evmContract);
     error NoEvmContract(uint32 index);
+    error PrecompileCallFailed();
 }


### PR DESCRIPTION
### Summary

Fix bug where `isWithdrawable()` compared `block.timestamp` (seconds) directly with `lockedUntilTimestamp` (milliseconds), causing funds to appear locked for ~55,000 years instead of the intended lock period.

### Changes
The fix uses `CoreWriterLib.toMilliseconds()` to properly convert `block.timestamp` to milliseconds before comparison, aligning with the pattern used in `CoreWriterLib._canWithdrawFromVault()`.