### PR TITLE
fix: correct timestamp comparison in VaultExample.isWithdrawable()

### DIFF
--- a/src/examples/VaultExample.sol
+++ b/src/examples/VaultExample.sol
@@ -97,7 +97,7 @@ contract VaultExample {
      */
     function isWithdrawable(address user, address vault) public view returns (bool withdrawable) {
         PrecompileLib.UserVaultEquity memory vaultEquity = PrecompileLib.userVaultEquity(user, vault);
-        return block.timestamp >= vaultEquity.lockedUntilTimestamp;
+        return CoreWriterLib.toMilliseconds(uint64(block.timestamp)) >= vaultEquity.lockedUntilTimestamp;
     }
 
     receive() external payable {}


### PR DESCRIPTION
### Summary

Fix bug where `isWithdrawable()` compared `block.timestamp` (seconds) directly with `lockedUntilTimestamp` (milliseconds), causing funds to appear locked for ~55,000 years instead of the intended lock period.

### Changes
The fix uses `CoreWriterLib.toMilliseconds()` to properly convert `block.timestamp` to milliseconds before comparison, aligning with the pattern used in `CoreWriterLib._canWithdrawFromVault()`.