### PR TITLE
feat: implement approveBuilderFee in CoreWriterLib

### DIFF
--- a/src/CoreWriterLib.sol
+++ b/src/CoreWriterLib.sol
@@ -194,4 +194,10 @@ library CoreWriterLib {
             )
         );
     }
+
+    function approveBuilderFee(uint64 maxFeeRate, address builder) internal {
+        coreWriter.sendRawAction(
+            abi.encodePacked(uint8(1), HLConstants.APPROVE_BUILDER_FEE_ACTION, abi.encode(maxFeeRate, builder))
+        );
+    }
 }

--- a/src/common/HLConstants.sol
+++ b/src/common/HLConstants.sol
@@ -60,6 +60,7 @@ library HLConstants {
     uint24 constant ADD_API_WALLET_ACTION = 9;
     uint24 constant CANCEL_ORDER_BY_OID_ACTION = 10;
     uint24 constant CANCEL_ORDER_BY_CLOID_ACTION = 11;
+    uint24 constant APPROVE_BUILDER_FEE_ACTION = 12;
 
     /*//////////////////////////////////////////////////////////////
                         Limit Order Time in Force

--- a/test/CoreSimulatorTest.t.sol
+++ b/test/CoreSimulatorTest.t.sol
@@ -521,6 +521,19 @@ contract CoreSimulatorTest is Test {
         );
     }
 
+    function test_approveBuilderFee() public {
+        vm.startPrank(user);
+        BuilderFeeApprover approver = new BuilderFeeApprover();
+        CoreSimulatorLib.forceAccountActivation(address(approver));
+
+        approver.approveBuilderFee(10, user);
+
+        approver.approveBuilderFee(type(uint64).max, USDT0);
+
+        address zeroFeeBuilder = makeAddr("zeroFeeBuilder");
+        approver.approveBuilderFee(0, zeroFeeBuilder);
+    }
+
     function test_usdc_creation_fee() public {
         vm.startPrank(user);
 
@@ -796,6 +809,12 @@ contract SpotTrader {
 
     function bridgeToCore(address asset, uint64 amount) public {
         CoreWriterLib.bridgeToCore(asset, amount);
+    }
+}
+
+contract BuilderFeeApprover {
+    function approveBuilderFee(uint64 maxFeeRate, address builder) public {
+        CoreWriterLib.approveBuilderFee(maxFeeRate, builder);
     }
 }
 


### PR DESCRIPTION
  Summary

  - Implements approveBuilderFee function in CoreWriterLib to allow contracts to approve builders with specified maximum fee rates
  - Adds new action constant `APPROVE_BUILDER_FEE_ACTION` for builder fee approvals
  - Includes test coverage for the new functionality

  Changes

  - `CoreWriterLib.sol`: Added `approveBuilderFee(uint64 maxFeeRate, address builder)` function that sends raw action to approve builders
  - `HLConstants.sol`: Added `APPROVE_BUILDER_FEE_ACTION = 12` constant
  - `CoreSimulatorTest.t.sol`: Added test cases covering:
    - Standard builder fee approval
    - Maximum fee rate approval
    - Zero fee rate approval

  Testing

  New functionality is covered by unit tests demonstrating various approval scenarios.