### PR TITLE
fix: precompile calls were returning empty results for non-initialised accounts

### DIFF
--- a/test/simulation/PrecompileSim.sol
+++ b/test/simulation/PrecompileSim.sol
@@ -72,8 +72,8 @@ contract PrecompileSim {
         }
 
         if (address(this) == ACCOUNT_MARGIN_SUMMARY_PRECOMPILE_ADDRESS) {
-            (uint16 perp, address user) = abi.decode(data, (uint16, address));
-            return abi.encode(_hyperCore.readAccountMarginSummary(perp, user));
+            (uint16 perp_dex_index, address user) = abi.decode(data, (uint16, address));
+            return abi.encode(_hyperCore.readAccountMarginSummary(perp_dex_index, user));
         }
 
         return _makeRpcCall(address(this), data);

--- a/test/simulation/hyper-core/CoreState.sol
+++ b/test/simulation/hyper-core/CoreState.sol
@@ -171,6 +171,10 @@ contract CoreState is StdCheats {
     }
 
     function _initializeAccount(address _account) internal {
+        _initializeAccount(_account, false);
+    }
+
+    function _initializeAccount(address _account, bool force) internal {
         bool initialized = _initializedAccounts[_account];
 
         if (initialized) {
@@ -181,7 +185,7 @@ contract CoreState is StdCheats {
 
         // check if the acc is created on Core
         RealL1Read.CoreUserExists memory coreUserExists = RealL1Read.coreUserExists(_account);
-        if (!coreUserExists.exists) {
+        if (!coreUserExists.exists && !force) {
             return;
         }
 
@@ -266,6 +270,9 @@ contract CoreState is StdCheats {
 
     /// @dev account creation can be forced when there isnt a reliance on testing that workflow.
     function forceAccountActivation(address account) public {
+
+        // force initialize the account
+        _initializeAccount(account, true);
         _accounts[account].activated = true;
     }
 

--- a/test/simulation/hyper-core/CoreView.sol
+++ b/test/simulation/hyper-core/CoreView.sol
@@ -75,17 +75,12 @@ contract CoreView is CoreState {
         return SafeCast.toUint64(uint256(_accounts[user].delegations[validator].amount) * multiplier / userLastMultiplier);
     }
 
-    function readDelegation(address user, address validator)
-        public
-        view
-        returns (PrecompileLib.Delegation memory delegation)
-    {
-        delegation.validator = validator;
-        delegation.amount = _getDelegationAmount(user, validator);
-        delegation.lockedUntilTimestamp = _accounts[user].delegations[validator].lockedUntilTimestamp;
-    }
+    function readDelegations(address user) public returns (PrecompileLib.Delegation[] memory userDelegations) {
 
-    function readDelegations(address user) public view returns (PrecompileLib.Delegation[] memory userDelegations) {
+        if (_accounts[user].activated == false) {
+            return RealL1Read.delegations(user);
+        }
+
         address[] memory validators = _accounts[user].delegatedValidators.values();
 
         userDelegations = new PrecompileLib.Delegation[](validators.length);
@@ -96,7 +91,12 @@ contract CoreView is CoreState {
         }
     }
 
-    function readDelegatorSummary(address user) public view returns (PrecompileLib.DelegatorSummary memory summary) {
+    function readDelegatorSummary(address user) public returns (PrecompileLib.DelegatorSummary memory summary) {
+
+        if (_accounts[user].activated == false) {
+            return RealL1Read.delegatorSummary(user);
+        }
+
         address[] memory validators = _accounts[user].delegatedValidators.values();
 
         for (uint256 i; i < validators.length; i++) {
@@ -113,7 +113,11 @@ contract CoreView is CoreState {
         }
     }
 
-    function readPosition(address user, uint16 perp) public view returns (PrecompileLib.Position memory) {
+    function readPosition(address user, uint16 perp) public returns (PrecompileLib.Position memory) {
+        if (_accounts[user].activated == false) {
+            return RealL1Read.position(user, perp);
+        }
+
         return _accounts[user].positions[perp];
     }
 
@@ -125,7 +129,7 @@ contract CoreView is CoreState {
         return _accounts[account].activated;
     }
 
-    function readAccountMarginSummary(uint16 perp, address user)
+    function readAccountMarginSummary(uint16 perp_dex_index, address user)
         public
         returns (PrecompileLib.AccountMarginSummary memory)
     {

--- a/test/unit-tests/CoreSimulatorTest.t.sol
+++ b/test/unit-tests/CoreSimulatorTest.t.sol
@@ -2,18 +2,18 @@
 pragma solidity ^0.8.0;
 
 import {Test, console} from "forge-std/Test.sol";
-import {PrecompileLib} from "../src/PrecompileLib.sol";
-import {HLConversions} from "../src/common/HLConversions.sol";
-import {HLConstants} from "../src/common/HLConstants.sol";
-import {BridgingExample} from "../src/examples/BridgingExample.sol";
-import {HyperCore} from "./simulation/HyperCore.sol";
-import {L1Read} from "./utils/L1Read.sol";
-import {HypeTradingContract} from "./utils/HypeTradingContract.sol";
-import {CoreSimulatorLib} from "./simulation/CoreSimulatorLib.sol";
-import {RealL1Read} from "./utils/RealL1Read.sol";
-import {CoreWriterLib} from "../src/CoreWriterLib.sol";
-import {VaultExample} from "../src/examples/VaultExample.sol";
-import {StakingExample} from "../src/examples/StakingExample.sol";
+import {PrecompileLib} from "../../src/PrecompileLib.sol";
+import {HLConversions} from "../../src/common/HLConversions.sol";
+import {HLConstants} from "../../src/common/HLConstants.sol";
+import {BridgingExample} from "../../src/examples/BridgingExample.sol";
+import {HyperCore} from "../simulation/HyperCore.sol";
+import {L1Read} from "../utils/L1Read.sol";
+import {HypeTradingContract} from "../utils/HypeTradingContract.sol";
+import {CoreSimulatorLib} from "../simulation/CoreSimulatorLib.sol";
+import {RealL1Read} from "../utils/RealL1Read.sol";
+import {CoreWriterLib} from "../../src/CoreWriterLib.sol";
+import {VaultExample} from "../../src/examples/VaultExample.sol";
+import {StakingExample} from "../../src/examples/StakingExample.sol";
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
 
 contract CoreSimulatorTest is Test {

--- a/test/unit-tests/StakingTest.t.sol
+++ b/test/unit-tests/StakingTest.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {PrecompileLib} from "../../src/PrecompileLib.sol";
+import {CoreSimulatorLib} from "../simulation/CoreSimulatorLib.sol";
+
+contract StakingBalanceTest is Test {
+    function setUp() public {
+        vm.createSelectFork("https://rpc.hyperliquid.xyz/evm");
+        CoreSimulatorLib.init();
+    }
+
+    function test_liveStakingBalance() public {
+        address stakingAddress = 0x77C3Ea550D2Da44B120e55071f57a108f8dd5E45;
+
+        PrecompileLib.DelegatorSummary memory summary = PrecompileLib.delegatorSummary(stakingAddress);
+        uint256 totalStaking = uint256(summary.delegated);
+
+        emit log_named_uint("total staking balance (core units)", totalStaking);
+
+        assertGt(totalStaking, 0);
+    }
+}
+
+


### PR DESCRIPTION
For accounts that have not been initialised in the simulator, precompile calls should read from onchain data, instead of reading from the simulator's empty state.