### PR TITLE
fix(core-execution): fixing executeSpotSend() failing when bridging hype to evm due to uint64 overflow

### DIFF
--- a/test/simulation/hyper-core/CoreExecution.sol
+++ b/test/simulation/hyper-core/CoreExecution.sol
@@ -346,7 +346,7 @@ contract CoreExecution is CoreView {
         } else {
             uint256 transferAmount;
             if (action.token == HYPE_TOKEN_INDEX) {
-                transferAmount = action._wei * 1e10;
+                transferAmount = uint256(action._wei) * 1e10;
                 deal(systemAddress, systemAddress.balance + transferAmount);
                 vm.startPrank(systemAddress);
                 (bool success,) = address(sender).call{value: transferAmount, gas: 30000}("");


### PR DESCRIPTION
Whenever you call `bridgeToEvm()` with Hype in a unit test, it fails if you do anything with an EVM balance that exceeds `type(uint64).max`. This is because inside of `executeSpotSend()`, `action._wei` is a uint64 and when it's multiplied by `1e10` (in order to convert it to an EVM amount), an overflow happens even though `transferAmount` is a uint256.

This PR just ensures that we cast `action._wei` to a uint256 before the multiplication takes place.