### PR TITLE
Fix Build Warnings

### DIFF
--- a/test/simulation/PrecompileSim.sol
+++ b/test/simulation/PrecompileSim.sol
@@ -96,8 +96,8 @@ contract PrecompileSim {
         }
 
         if (address(this) == ACCOUNT_MARGIN_SUMMARY_PRECOMPILE_ADDRESS) {
-            (uint16 perp_dex_index, address user) = abi.decode(data, (uint16, address));
-            return abi.encode(_hyperCore.readAccountMarginSummary(perp_dex_index, user));
+            address user = abi.decode(data, (address));
+            return abi.encode(_hyperCore.readAccountMarginSummary(user));
         }
 
         return _makeRpcCall(address(this), data);

--- a/test/simulation/hyper-core/CoreExecution.sol
+++ b/test/simulation/hyper-core/CoreExecution.sol
@@ -133,9 +133,6 @@ contract CoreExecution is CoreView {
                 uint64 avgEntryPrice = _accounts[sender].positions[perpIndex].entryNtl / uint64(-szi);
                 int64 pnl = int64(action.sz) * (int64(avgEntryPrice) - int64(_markPx));
 
-                uint64 closedMargin =
-                    (uint64(action.sz) * _accounts[sender].positions[perpIndex].entryNtl / uint64(-szi)) / leverage;
-
                 _accounts[sender].perpBalance = pnl > 0
                     ? _accounts[sender].perpBalance + uint64(pnl)
                     : _accounts[sender].perpBalance - uint64(-pnl);
@@ -150,7 +147,6 @@ contract CoreExecution is CoreView {
                     : _accounts[sender].perpBalance - uint64(-pnl);
 
                 uint64 newLongSize = uint64(newSzi);
-                uint64 newMargin = newLongSize * _markPx / leverage;
 
                 _accounts[sender].positions[perpIndex].szi = newSzi;
                 _accounts[sender].positions[perpIndex].entryNtl = newLongSize * _markPx;
@@ -200,8 +196,6 @@ contract CoreExecution is CoreView {
             if (newSzi >= 0) {
                 uint64 avgEntryPrice = _accounts[sender].positions[perpIndex].entryNtl / uint64(szi);
                 int64 pnl = int64(action.sz) * (int64(_markPx) - int64(avgEntryPrice));
-                uint64 closedMargin =
-                    (uint64(action.sz) * _accounts[sender].positions[perpIndex].entryNtl / uint64(szi)) / leverage;
 
                 _accounts[sender].perpBalance = pnl > 0
                     ? _accounts[sender].perpBalance + uint64(pnl)
@@ -217,7 +211,6 @@ contract CoreExecution is CoreView {
                     : _accounts[sender].perpBalance - uint64(-pnl);
 
                 uint64 newShortSize = uint64(-newSzi);
-                uint64 newMargin = newShortSize * _markPx / leverage;
 
                 _accounts[sender].positions[perpIndex].szi = newSzi;
                 _accounts[sender].positions[perpIndex].entryNtl = newShortSize * _markPx;

--- a/test/simulation/hyper-core/CoreView.sol
+++ b/test/simulation/hyper-core/CoreView.sol
@@ -167,7 +167,7 @@ contract CoreView is CoreState {
         return _accounts[account].activated;
     }
 
-    function readAccountMarginSummary(uint16 perp_dex_index, address user)
+    function readAccountMarginSummary(address user)
         public
         returns (PrecompileLib.AccountMarginSummary memory)
     {


### PR DESCRIPTION
There were a few build warnings in our project showing from the downstream hyper-evm-lib dependency. Thought it's probably worth cleaning these up. Wasn't sure about the `readAccountMarginSummary` view, as this is potentially a breaking change so might be out of scope of fixing build warnings. But I couldn't see a use for the param so thought would raise anyway and get input. 

<img width="772" height="407" alt="image" src="https://github.com/user-attachments/assets/5992d044-f1fd-48dc-83d4-750a8f804077" />
